### PR TITLE
use 'export type' for reexporting types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-export { Runtype } from './runtype.ts';
-export type { Static } from './runtype.ts'
+export type { Runtype, Static } from './runtype.ts'
 export * from './reflect.ts';
 export * from './result.ts';
 export * from './contract.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { Runtype, Static } from './runtype.ts';
+export { Runtype } from './runtype.ts';
+export type { Static } from './runtype.ts'
 export * from './reflect.ts';
 export * from './result.ts';
 export * from './contract.ts';


### PR DESCRIPTION
I've been trying to use the library from Deno, and had an error message concerning this. Wouldn't work otherwise.
